### PR TITLE
fix: :hammer: update test snippet to given, when, then

### DIFF
--- a/.vscode/python.code-snippets
+++ b/.vscode/python.code-snippets
@@ -13,20 +13,19 @@
 	// 	"description": "Log output to console"
 	// }
 	"Insert a Python test": {
-		"prefix": "test-aaa",
+		"prefix": "test-gwt",
 		"body": [
 			"def test_$1():",
-			"		# Arrange",
-			"		$2",
-			"		",
-			"		# Act",
-			"		$3",
-			"		",
-			"		# Assert",
-			"		$4",
+			"	# Given",
+			"	$2",
+			"	",
+			"	# When",
+			"	$3",
+			"	",
+			"	# Then",
+			"	$4",
 			"",
 		],
-		"description": "Create AAA test"
+		"description": "Create Given-When-Then test"
 	}
-
 }


### PR DESCRIPTION
Since we have moved away from AAA.
Alternatively, this can be removed. I'm not sure anyone uses it. 

(Saw it this morning during the status meeting, when looking at the `examples` repo and was reminded that I made this change a while ago without pushing it)

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [ ] Ran `just run-all`
(`just run-all` failed with message: "template-python-project/NAME does not contain any element
error: Recipe `install-deps` failed on line 9 with exit code 1")