### PR TITLE
fix: :bug: remove auto-built reference docs before/after building

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,7 @@
 project:
   type: seedcase-theme
+  # Delete auto-generated files from `quartodoc`
+  post-render: rm docs/reference/*.qmd
   render:
     - "docs/*"
     - "index.qmd"

--- a/justfile
+++ b/justfile
@@ -25,6 +25,8 @@ format-python:
 build-website:
   # To let Quarto know where python is.
   export QUARTO_PYTHON=.venv/bin/python3
+  # Delete any previously built files from quartodoc
+  rm docs/reference/*.qmd
   poetry run quartodoc build
   poetry run quarto render --execute
 


### PR DESCRIPTION
## Description

Whenever we delete an old function, the quartodoc doesn't remove the old `reference/*.qmd` file. So this solves that problem.

<!-- Select quick/in-depth as necessary -->
Doesn't need a review
