### PR TITLE
ci: :construction_worker: lint is now part of build workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -13,10 +13,8 @@ on:
       - "docs/**"
       - "*.md"
       - "*.qmd"
-      - "justfile"
       # Website files
       - _quarto.yml
-      - index.qmd
       - _publish.yml
       - _extensions/**
   push:
@@ -24,9 +22,5 @@ on:
       - main
 
 jobs:
-  lint:
-    uses: seedcase-project/.github/.github/workflows/reusable-lint-python.yml@main
-
-  test:
-    uses: seedcase-project/.github/.github/workflows/reusable-test-python.yml@main
-    needs: lint
+  build:
+    uses: seedcase-project/.github/.github/workflows/reusable-build-python.yml@main


### PR DESCRIPTION
## Description

Based on the changes in the `.github` repo, the lint workflow was removed and merged into a general "build" workflow. So this matches that workflow.

<!-- Select quick/in-depth as necessary -->
Doesn't need a review.
