### PR TITLE
build: :hammer: move pytest options into `pytest.ini` so VS Code detects them

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -13,6 +13,8 @@ group:
         dest: justfile
       - source: .cz.toml
         dest: .cz.toml
+      - source: pytest.ini
+        dest: pytest.ini
       - source: ruff.toml
         dest: ruff.toml
       - source: LICENSE.md

--- a/justfile
+++ b/justfile
@@ -10,21 +10,7 @@ install-deps:
 
 # Run the Python tests
 test-python:
-  # - A short traceback (tb) mode to make it easier to view
-  # - Use the `src/` package (importlib)
-  # - Use code coverage on the `src/` package
-  # - If tests fail, do not generate coverage report
-  # - Create the coverage report in XML (for badge), terminal, and HTML
-  # - Trigger failure if below 90% code coverage
-  uv run pytest \
-    --tb=short \
-    --import-mode=importlib \
-    --cov=src \
-    --no-cov-on-fail \
-    --cov-report=term \
-    --cov-report=xml \
-    --cov-report=html \
-    --cov-fail-under=90
+  uv run pytest
   # Make the badge from the coverage report
   uv run genbadge coverage \
     -i coverage.xml \

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+# - A short traceback (tb) mode to make it easier to view
+# - Use the `src/` package (importlib)
+# - Use code coverage on the `src/` package
+# - If tests fail, do not generate coverage report
+# - Create the coverage report in XML (for badge), terminal, and HTML
+# - Trigger failure if below 90% code coverage
+addopts = --tb=short --import-mode=importlib --cov=src --no-cov-on-fail --cov-report=term --cov-report=xml --cov-report=html --cov-fail-under=90


### PR DESCRIPTION
## Description

To match changes made in Sprout.
