### PR TITLE
chore: :wrench: remove leftover extensions, replace spell checker

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,22 +1,17 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-  // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
     "donjayamanne.githistory",
     "felipecaputo.git-project-manager",
     "GitHub.vscode-pull-request-github",
-    "ms-azuretools.vscode-docker",
     "ms-python.python",
     "ms-python.vscode-pylance",
     "njpwerner.autodocstring",
     "quarto.quarto",
     "ms-toolsai.jupyter",
-    "streetsidesoftware.code-spell-checker",
     "vivaxy.vscode-conventional-commits",
     "charliermarsh.ruff",
     "pshaddel.conventional-branch",
-    "yy0931.vscode-sqlite3-editor"
+    "tekumara.typos-vscode"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,10 +32,6 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.languageServer": "Pylance",
   "files.insertFinalNewline": true,
-  "cSpell.enabledFileTypes": {
-    "quarto": true
-  },
-  "cSpell.language": "en,en-GB",
   "python.testing.pytestEnabled": true,
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
 }


### PR DESCRIPTION
## Description

This removes the `cSpell` vscode extension, replaces it with `typos` extension. And removes some leftover extensions we don't need.

Closes #37
