### PR TITLE
ci: :lock: use GitHub App for short-lived token creation

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -8,5 +8,7 @@ on:
 jobs:
   update-version:
     uses: seedcase-project/.github/.github/workflows/reusable-update-python-project-version.yml@main
+    with:
+      app-id: ${{ vars.UPDATE_VERSION_APP_ID }}
     secrets:
       update-version-gh-token: ${{ secrets.UPDATE_VERSION_TOKEN }}


### PR DESCRIPTION
## Description

Adds the app id for the reusable workflow.


<!-- Select quick/in-depth as necessary -->
No review needed.
