### PR TITLE
ci: :memo: use a shorter name for workflow

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,4 +1,4 @@
-name: Build website of documentation
+name: Build website
 
 on:
   push:


### PR DESCRIPTION
## Description

When using badges, it takes it from the name. So this is a small improvement to have the workflow name shorter.

Doesn't need a review.