### PR TITLE
ci: :bug: needs to be `GH_INSTALLATION_TOKEN` for GitHub Apps

### DIFF
--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ steps.app-token.outputs.token }}
+          GH_INSTALLATION_TOKEN: ${{ steps.app-token.outputs.token }}
           ASSIGNEES: lwjohnst86
           IS_FINE_GRAINED: true
           GIT_USERNAME: github-actions[bot]


### PR DESCRIPTION
## Description

The workflow needs this config field.