### PR TITLE
ci: :passport_control: add permissions for setting release of a tag

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   update-version:
     uses: seedcase-project/.github/.github/workflows/reusable-update-python-project-version.yml@main


### PR DESCRIPTION
## Description

The release workflow is complaining of permissions. I think this will fix it.

<!-- Select quick/in-depth as necessary -->
No review needed.
