### PR TITLE
build: :wrench: don't regenerate all of CHANGELOG each time

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,3 +2,5 @@
 bump_message = "build(version): :bookmark: update version from $current_version to $new_version [skip ci]"
 update_changelog_on_bump = true
 version_provider = "uv"
+# Don't regenerate the changelog on every update
+changelog_incremental = true


### PR DESCRIPTION
## Description

Updates from the change made in Sprout. Don't merge until that PR has been merged.
