### PR TITLE
ci: :lock: add security scanning workflows

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -31,6 +31,8 @@ group:
         dest: .github/workflows/build-website.yml
       - source: .github/workflows/update-version.yml
         dest: .github/workflows/update-version.yml
+      - source: .github/workflows/scorecards.yml
+        dest: .github/workflows/scorecards.yml
       - source: .github/_project-dependabot.yml
         dest: .github/dependabot.yml
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: "Security: Dependency Review"
+on: pull_request
+
+# Limit token permissions for security
+permissions: read-all
+
+jobs:
+  dependency-review:
+    uses: seedcase-project/.github/.github/workflows/reusable-dependency-review.yml@main

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,28 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+name: "Security: Scorecard"
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 7 * * 2'
+  push:
+    branches:
+      - main
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Analysis
+    uses: seedcase-project/.github/.github/workflows/reusable-scorecards.yml@main
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write


### PR DESCRIPTION
# Description

Adds the security workflows, using the reusable ones I made, so that they get synced.

No review needed.