### PR TITLE
ci: :construction_worker: use `GH_TOKEN` to use `gh` cli

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -8,6 +8,10 @@ on:
 # Limit token permissions for security
 permissions: read-all
 
+# This is to allow using `gh` CLI
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build-website:
     uses: seedcase-project/.github/.github/workflows/reusable-build-docs-with-python.yml@main


### PR DESCRIPTION
# Description

`gh` needs this env variable.

No review needed.

