### PR TITLE
ci: :construction_worker: Move `GITHUB_TOKEN` into `github-token` secrets

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -8,12 +8,10 @@ on:
 # Limit token permissions for security
 permissions: read-all
 
-# This is to allow using `gh` CLI
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   build-website:
     uses: seedcase-project/.github/.github/workflows/reusable-build-docs-with-python.yml@main
     secrets:
       netlify-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      # This is to allow using `gh` CLI
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Need to pass the `GITHUB_TOKEN` directly into the reusable workflow, not use it outside.

No review needed.