### PR TITLE
chore: :wrench: fix spacing for snippet, use 4 spaces, not 1

### DIFF
--- a/.vscode/python.code-snippets
+++ b/.vscode/python.code-snippets
@@ -1,31 +1,31 @@
 {
-	// Place your snippets for python here. Each snippet is defined under a snippet name and has a prefix, body and
-	// description. The prefix is what is used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
-	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. Placeholders with the
-	// same ids are connected.
-	// Example:
-	// "Print to console": {
-	// 	"prefix": "log",
-	// 	"body": [
-	// 		"console.log('$1');",
-	// 		"$2"
-	// 	],
-	// 	"description": "Log output to console"
-	// }
-	"Insert a Python test": {
-		"prefix": "test-gwt",
-		"body": [
-			"def test_$1():",
-			"	# Given",
-			"	$2",
-			"	",
-			"	# When",
-			"	$3",
-			"	",
-			"	# Then",
-			"	$4",
-			"",
-		],
-		"description": "Create Given-When-Then test"
-	}
+  // Place your snippets for python here. Each snippet is defined under a snippet name and has a prefix, body and
+  // description. The prefix is what is used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. Placeholders with the
+  // same ids are connected.
+  // Example:
+  // "Print to console": {
+  // 	"prefix": "log",
+  // 	"body": [
+  // 		"console.log('$1');",
+  // 		"$2"
+  // 	],
+  // 	"description": "Log output to console"
+  // }
+  "Insert a Python test": {
+    "prefix": "test-gwt",
+    "body": [
+      "def test_$1():",
+      "    # Given",
+      "    $2",
+      "    ",
+      "    # When",
+      "    $3",
+      "    ",
+      "    # Then",
+      "    $4",
+      "",
+    ],
+    "description": "Create Given-When-Then test"
+  }
 }


### PR DESCRIPTION
# Description

Match what was done in Sprout.

No review needed.