### PR TITLE
fix: :bug: install uv in publish step and only for tags

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -30,12 +30,16 @@ jobs:
       name: pypi
     needs:
       - release-package
+    if: github.ref_type == 'tag'
     steps:
       - name: Download built distributions
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-dists
           path: dist/
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
 
       - name: Publish 📦 to PyPI
         # Only publish if the option is explicitly set in the calling workflow.


### PR DESCRIPTION
# Description

Forgot to setup uv. Also made it so it only runs on tags.

No review needed.