### PR TITLE
fix: :construction_worker: use the `has_released` output to run or not

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   release-package:
+    # This job outputs a env variable called `has_released` that is `true` if the release was successful.
     # Only give permissions for this job.
     permissions:
       contents: write
@@ -30,7 +31,7 @@ jobs:
       name: pypi
     needs:
       - release-package
-    if: github.ref_type == 'tag'
+    if: ${{ needs.release-package.outputs.has_released == 'true' }}
     steps:
       - name: Download built distributions
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
# Description

The `if` conditional doesn't work very well. Hopefully this works, but won't be able to see if it does until another release.

No review needed.