### PR TITLE
fix: :construction_worker: only run when previous and current versions are different

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -10,7 +10,7 @@ permissions: read-all
 
 jobs:
   release-package:
-    # This job outputs a env variable called `has_released` that is `true` if the release was successful.
+    # This job outputs env variables `previous_version` and `current_version`.
     # Only give permissions for this job.
     permissions:
       contents: write
@@ -31,7 +31,7 @@ jobs:
       name: pypi
     needs:
       - release-package
-    if: ${{ needs.release-package.outputs.has_released == 'true' }}
+    if: ${{ needs.release-package.outputs.previous_version != needs.release-package.outputs.current_version }}
     steps:
       - name: Download built distributions
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
# Description

The previous `if` didn't work. This should hopefully work, as it compares the versions and only runs if there is a change.

No review needed.
