### PR TITLE
chore: :technologist: recommend better reviewed mypy extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,7 @@
     "GitHub.vscode-pull-request-github",
     "ms-python.python",
     "ms-python.vscode-pylance",
-    "ms-python.mypy-type-checker",
+    "matangover.mypy",
     "njpwerner.autodocstring",
     "quarto.quarto",
     "ms-toolsai.jupyter",


### PR DESCRIPTION
# Description

The MS version of the mypy extension was not as well reviewed. This one is better, plus, the setting used in `settings.json` was for this extension, not the other one.

No review needed.
