### PR TITLE
fix: :construction_worker: explicitly checkout newest version to publish

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -40,6 +40,10 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Need to explicitly get the current version, otherwise it defaults to current commit
+          # (which is not the same as the release/version commit).
+          ref: ${{ needs.release.outputs.current_version }}
 
       # This workflow and the publish workflows are based on:
       # - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/


### PR DESCRIPTION
# Description

Currently, the publish step checks out the current *commit*, which isn't the same as the current version (the previous step creates a release commit with version bumping). This PR fixes that to explicitly checkout the newest version (tag).

No review needed.