### PR TITLE
fix: :bug: need to run build workflow after version bump to get changelog

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-bump_message = "build(version): :bookmark: update version from $current_version to $new_version [skip ci]"
+bump_message = "build(version): :bookmark: update version from $current_version to $new_version"
 update_changelog_on_bump = true
 version_provider = "uv"
 # Don't regenerate the changelog on every update


### PR DESCRIPTION
# Description

The website needs the version bump commit to regenerate the changelog page.

This PR needs a quick review.

