### PR TITLE
docs: :memo: add Code of Conduct file to root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect
+all people who contribute through reporting issues, posting suggestions,
+updating any material, submitting pull requests, and other activities.
+
+We are committed to making participation in this project a
+harassment-free experience for everyone, regardless of level of
+experience, gender, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, ethnicity, age, or
+religion.
+
+Examples of unacceptable behavior by participants include the use of
+sexual language or imagery, derogatory comments or personal attacks,
+trolling, public or private harassment, insults, or other unprofessional
+conduct.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct. Project
+maintainers who do not follow the Code of Conduct may be removed from
+the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(https://contributor-covenant.org), version 1.0.0, available at
+https://contributor-covenant.org/version/1/0/0/

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ for information on how to contribute to the project, including how to
 set up your development environment.
 
 Please note that this project is released with a [Contributor Code of
-Conduct](https://github.com/seedcase-project/.github/blob/main/CODE_OF_CONDUCT.md).
-By participating in this project you agree to abide by its terms.
+Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree
+to abide by its terms.
 
 ## Licensing
 

--- a/README.qmd
+++ b/README.qmd
@@ -34,11 +34,8 @@ for information on how to contribute to the project, including how to
 set up your development environment.
 
 Please note that this project is released with a [Contributor Code of
-Conduct](https://github.com/{{< meta gh.org >}}/.github/blob/main/CODE_OF_CONDUCT.md).
-By participating in this project you agree to abide by its terms.
-
-::: content-hidden
-<!-- TODO: Unhide after more contributors -->
+Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree
+to abide by its terms.
 
 ### Contributors
 

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ update-quarto-theme:
 
 # Update files in the template from the copier parent folder
 update-template:
-  cp .pre-commit-config.yaml .typos.toml .editorconfig template/
+  cp CODE_OF_CONDUCT.md .pre-commit-config.yaml .typos.toml .editorconfig template/
   mkdir -p template/tools
   cp tools/get-contributors.sh template/tools/
   cp .github/pull_request_template.md template/.github/


### PR DESCRIPTION
# Description

Adds a `CODE_OF_CONDUCT.md` to the root project, and refer to this file, not the `.github` repo one.

This PR needs a quick review.
