### PR TITLE
docs: :page_facing_up: match author style of LICENSE to the template

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023-2025 Aarhus University
+Copyright (c) 2023-2025 template-python-package authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ By participating in this project you agree to abide by its terms.
 
 ## Licensing
 
-This project is licensed under the [MIT
-License](https://github.com/seedcase-project/template-python-package/blob/main/LICENSE.md).
+This project is licensed under the [MIT License](LICENSE.md).
 
 ## Citing
 

--- a/README.qmd
+++ b/README.qmd
@@ -47,8 +47,7 @@ By participating in this project you agree to abide by its terms.
 
 ## Licensing
 
-This project is licensed under the [MIT
-License](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/blob/main/LICENSE.md).
+This project is licensed under the [MIT License](LICENSE.md).
 
 ## Citing
 

--- a/index.qmd
+++ b/index.qmd
@@ -68,5 +68,4 @@ share your ideas or contribute code. Your input makes us better!
 
 ## Licensing
 
-This project is licensed under the [MIT
-License](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/blob/main/LICENSE.md).
+This project is licensed under the [MIT License](/LICENSE.md).


### PR DESCRIPTION
# Description

Using this style since a template generator (to my understanding) is less software and more of an opinion on a structured set of files/folders, so doesn't exactly fall under the same copyright rules. 

Plus updated links to the license to refer to it at the root folder.

This PR needs a quick review.
