### PR TITLE
refactor: :hammer: use `--upgrade` when installing Python dependencies

### DIFF
--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -31,7 +31,7 @@ update-quarto-theme:
 {% endif %}
 # Install Python package dependencies
 install-deps:
-  uv sync --all-extras --dev
+  uv sync --all-extras --dev --upgrade
 
 # Run the Python tests
 test-python:


### PR DESCRIPTION
# Description

So that we always use the latest versions. This is important for when we depend on our own packages, e.g. `check-datapackage`.

Closes #169

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
