### PR TITLE
refactor: :wrench: can render everything in Quarto project

### DIFF
--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -3,11 +3,6 @@ project:
   type: website
   # Delete auto-generated files from `quartodoc`
   post-render: rm -f docs/reference/*.qmd
-  render:
-    - "docs/*"
-    - "index.qmd"
-    - "404.qmd"
-    - "CONTRIBUTING.md"
 
 website:
   # TODO: Fill in the title of the website.


### PR DESCRIPTION
# Description

We don't need to set `render:` there usually isn't anything to not render. So we don't need these settings.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
