### PR TITLE
refactor: :truck: rename to `check-python`, not `build`

### DIFF
--- a/template/.github/workflows/check-package.yml
+++ b/template/.github/workflows/check-package.yml
@@ -1,4 +1,4 @@
-name: Build package
+name: Check package
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ permissions: read-all
 
 jobs:
   build:
-    uses: seedcase-project/.github/.github/workflows/reusable-build-python.yml@main
+    uses: seedcase-project/.github/.github/workflows/reusable-check-python.yml@main
     # Permissions needed for pushing to the coverage branch.
     permissions:
       contents: write

--- a/template/docs/includes/_badges.qmd
+++ b/template/docs/includes/_badges.qmd
@@ -5,7 +5,7 @@
 [![GitHub License](https://img.shields.io/github/license/{{< meta gh.org >}}/{{< meta gh.repo >}}.svg)](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/blob/main/LICENSE.md)
 [![GitHub Release](https://img.shields.io/github/v/release/{{< meta gh.org >}}/{{< meta gh.repo >}}.svg)](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/releases/latest)
 [![Build documentation](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/build-website.yml/badge.svg)](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/build-website.yml)
-[![Build package](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/build-package.yml/badge.svg)](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/build-package.yml)
+[![Check package](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/check-package.yml/badge.svg)](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/check-package.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/badge?raw=true.svg)](https://scorecard.dev/viewer/?uri=github.com/{{< meta gh.org >}}/{{< meta gh.repo >}})
 [![CodeQL](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/actions/workflows/github-code-scanning/codeql)
 [![code coverage](https://raw.githubusercontent.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/coverage/coverage.svg?raw=true)](https://htmlpreview.github.io/?https://raw.githubusercontent.com/{{< meta gh.org >}}/{{< meta gh.repo >}}/coverage/index.html)


### PR DESCRIPTION
# Description

This workflow checks, not builds.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
