### PR TITLE
fix: :hammer: ignore other dirs and files when listing todos

### DIFF
--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -14,7 +14,12 @@ run-all: install-deps format-python _checks _tests _builds
 
 # List all TODO items in the repository
 list-todos:
-  grep -R -n --exclude="*.code-snippets" --exclude="justfile" "TODO" *
+  grep -R -n \
+    --exclude="*.code-snippets" \
+    --exclude-dir=.quarto \
+    --exclude=justfile \
+    --exclude=_site \
+    "TODO" *
 
 # Install the pre-commit hooks
 install-precommit:


### PR DESCRIPTION
# Description

These are not necessary to list TODOs in.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
