### PR TITLE
ci: :construction_worker: run Dependabot every month (and not assign anyone)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: ci
       include: scope
-    assignees:
-      - "lwjohnst86"


### PR DESCRIPTION
# Description

I think every week is too much.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
