### PR TITLE
ci: :construction_worker: no need to pass `GITHUB_TOKEN` (it was for contributors file)

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -13,5 +13,3 @@ jobs:
     uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
     secrets:
       netlify-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      # This is to allow using `gh` CLI
-      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Since we run `get_contributors.sh` outside of Quarto, we don't need to give the `GITHUB_TOKEN` to the workflow anymore.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
