### PR TITLE
fix: :bug: Quarto auto-adds this line, this fixes it so Quarto stops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docs/.quarto/
 *.ipynb
 *.quarto_ipynb
 *.storage
+**/*.quarto_ipynb
 
 # Quartodoc
 /docs/reference/

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -69,6 +69,7 @@ cover/
 docs/.quarto/
 *.ipynb
 *.quarto_ipynb
+**/*.quarto_ipynb
 *.storage
 
 # Quartodoc


### PR DESCRIPTION
# Description

Quarto always auto-adds this particular line in the `.gitignore` file. So just adding it here so it can stop auto-adding it.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
