### PR TITLE
feat: :sparkles: use ruff to check for unused arguments instead of vulture

### DIFF
--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -126,7 +126,7 @@ check-unused:
   # - 60 %: attribute, class, function, method, property, variable
   # There are some things should be ignored though, with the allowlist.
   # Create an allowlist with `vulture --make-allowlist`
-  uv run vulture src/ tests/ **/vulture-allowlist.py
+  uv run vulture --min-confidence 100 src/ tests/ **/vulture-allowlist.py
 
 # Re-build the README file from the Quarto version
 build-readme:

--- a/template/ruff.toml
+++ b/template/ruff.toml
@@ -9,7 +9,9 @@ extend-select = [
   # Add rule that all functions have docstrings.
   "D",
   # Add isort to list.
-  "I"
+  "I",
+  # Check for unused arguments
+  "ARG",
 ]
 # Ignore missing docstring at the top of files
 ignore = ["D100"]


### PR DESCRIPTION
# Description

I haven't done any extensive comparison, but I noticed some false positives with vulture for Enum constants that ruff did not flag. It is also more convenient that this is marked up by ruff in the editor instead of just when running the justfile.

Closes https://github.com/seedcase-project/template-python-package/issues/241
Needs a quick review.

## Checklist

- [x] Ran `just run-all`
