### PR TITLE
fix: 🔧 ignore spell checking in auto-generated `site_libs/`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,5 +5,6 @@ extend-exclude = [
   ".quarto/*",
   "_site/*",
   "_extensions/*",
-  ".coverage-report/*"
+  ".coverage-report/*",
+  "site_libs/",
 ]

--- a/template/.typos.toml
+++ b/template/.typos.toml
@@ -5,5 +5,6 @@ extend-exclude = [
   ".quarto/*",
   "_site/*",
   "_extensions/*",
-  ".coverage-report/*"
+  ".coverage-report/*",
+  "site_libs/",
 ]


### PR DESCRIPTION
# Description

This tended to render a lot of typos from js files etc, that makes it difficult to parse the output from just run-all / _checks

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
