### PR TITLE
refactor: 🔨 switch to using `uvx` for dev tooling, `uv run` isn't needed

### DIFF
--- a/template/TODO.md
+++ b/template/TODO.md
@@ -4,7 +4,7 @@
   after copying the project.
 - Run `git init -b main` to create the project as a Git repository.
 - Install these packages
-  `uv add --dev pre-commit ruff typos pytest bandit commitizen genbadge jupyter pytest-cov quartodoc types-tabulate mypy vulture`
+  `uv add --dev pytest genbadge jupyter pytest-cov quartodoc quarto types-tabulate mypy`
 - Run `just list-todos` and complete all the TODO items.
 - Run `just install-precommit` to install the pre-commit hooks.
 - Run `just build-readme` to build the Markdown version of the README.

--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -54,14 +54,14 @@ test-python:
 # Check Python code for any errors that need manual attention
 check-python:
   # Check formatting
-  uv run ruff check .
+  uvx ruff check .
   # Check types
   uv run mypy --pretty .
 
 # Reformat Python code to match coding style and general structure
 format-python:
-  uv run ruff check --fix .
-  uv run ruff format .
+  uvx ruff check --fix .
+  uvx ruff format .
 
 # Format Markdown files
 format-md:
@@ -99,11 +99,11 @@ check-commits:
 
 # Run basic security checks on the package
 check-security:
-  uv run bandit -r src/
+  uvx bandit -r src/
 
 # Check for spelling errors in files
 check-spelling:
-  uv run typos
+  uvx typos
 
 # Install lychee from https://lychee.cli.rs/guides/getting-started/
 # Check that URLs work
@@ -133,7 +133,7 @@ check-unused:
   # - 60 %: attribute, class, function, method, property, variable
   # There are some things should be ignored though, with the allowlist.
   # Create an allowlist with `vulture --make-allowlist`
-  uv run vulture --min-confidence 100 src/ tests/ **/vulture-allowlist.py
+  uvx vulture --min-confidence 100 src/ tests/ **/vulture-allowlist.py
 
 # Re-build the README file from the Quarto version
 build-readme:


### PR DESCRIPTION
# Description

That way we don't need to include them in our venv library.

Closes #279

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
