### PR TITLE
refactor: 🔨 remove `build-pdf` from justfile, not needed anymore

### DIFF
--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -113,16 +113,6 @@ check-urls:
     --extensions md,qmd,py \
     --exclude-path "_badges.qmd"
 
-# Build the documentation as PDF using Quarto
-build-pdf:
-  # To let Quarto know where python is.
-  export QUARTO_PYTHON=.venv/bin/python3
-  uv run quarto install tinytex
-  # For generating images from Mermaid diagrams
-  uv run quarto install chromium
-  uv run quarto render --profile pdf --to pdf
-  find docs -name "mermaid-figure-*.png" -delete
-
 # Check for unused code in the package and its tests
 check-unused:
   # exit code=0: No unused code was found


### PR DESCRIPTION
# Description

This was initially to build a PDF file of the docs and upload separately to Zenodo. But after various redesigns and changes to how we do things, this isn't relevant anymore (e.g. with eventual publishing of zen-do along with how we might use community repo for publishing reports/papers).

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
