### PR TITLE
fix: 🐛 remove extra quartodoc build step

### DIFF
--- a/template/.github/workflows/checks.yml
+++ b/template/.github/workflows/checks.yml
@@ -124,9 +124,6 @@ jobs:
       - name: Build function reference docs
         run: uv run quartodoc build
 
-      - name: Build function reference docs
-        run: uvx quartodoc build
-
       # Check that the website builds, but don't publish it
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0


### PR DESCRIPTION
# Description

This PR removes a leftover quartodoc build step that was making the build fail.

Closes #321

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
