### PR TITLE
fix: 🐛 move quartodoc renderer into root folder

### DIFF
--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -48,7 +48,7 @@ website:
       style: "floating"
       contents:
         - docs/index.qmd
-        - CHANGELOG.qmd
+        - CHANGELOG.md
         - CONTRIBUTING.md
     - id: design
       contents:
@@ -67,7 +67,7 @@ quartodoc:
   parser: google
   dynamic: true
   renderer:
-    style: .config/quartodoc.py
+    style: "quartodoc_style.py"
     table_style: description-list
     show_signature_annotations: true
 

--- a/template/quartodoc_style.py
+++ b/template/quartodoc_style.py
@@ -1,4 +1,5 @@
 """Custom quartodoc renderer that fixes the output of returns and raises sections."""
+# ruff: noqa
 
 from __future__ import annotations
 


### PR DESCRIPTION
# Description

This needs to be in the root folder, otherwise quartodoc fails.

Needs no review.

## Checklist

- [x] Ran `just run-all`
