### PR TITLE
fix: 🐛 remove Pyrefly from pre-commit, as `pre-commit.ci` fails with it

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -43,13 +43,3 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-
-  - repo: https://github.com/facebook/pyrefly-pre-commit
-    # Note: this is the version of the pre-commit hook, NOT the pyrefly version used for type checking.
-    rev: 1.2.0.dev1
-    hooks:
-      - id: pyrefly-check
-        name: Pyrefly (type checking)
-        # Recommended to do full repo checks, not just on changed files.
-        pass_filenames: false
-        language: system


### PR DESCRIPTION
# Description

The pre-commit requires a system install, but `pre-commit.ci` doesn't include custom ways of installing things. So just remove it, it's part of the justfile and CI checks anyway.

Needs no review.

## Checklist

- [x] Ran `just run-all`
