### PR TITLE
build: 🔨 do not run rumdl on Jinja files, it mangles them

### DIFF
--- a/justfile
+++ b/justfile
@@ -58,8 +58,6 @@ check-urls:
 format-md:
   # Use both rumdl and panache, for different purposes
   uvx rumdl fmt --silent
-  # `includes` option doesn't work with Jinja files, so do manually
-  uvx rumdl fmt --silent **/*.qmd.jinja **/*.md.jinja
   uvx --from panache-cli panache format . --quiet
 
 # Test template creation with specific parameters: LIST


### PR DESCRIPTION
# Description

Some Jinja shortcodes get mangled by rumdl, so this just removes that line from the justfile so it doesn't run on them.

Needs no review.

## Checklist

- [x] Ran `just run-all`
