### PR TITLE
fix: 🐛 correct Pyrefly settings to actually run in our projects

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -49,19 +49,22 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
-# - A short traceback (tb) mode to make it easier to view
-# - Use the `src/` package (importlib)
-# - Use code coverage on the `src/` package
-# - If tests fail, do not generate coverage report
-# - Create the coverage report in XML (for badge), terminal, and HTML
-# - Trigger failure if below 90% code coverage
+# - A short traceback (tb) mode to make it easier to view.
+# - Use the `src/` package (importlib).
+# - Use code coverage on the `src/` package.
+# - If tests fail, do not generate coverage report.
+# - Create the coverage report in XML (for badge), terminal, and HTML.
+# - Trigger failure if below 90% code coverage.
 addopts = "--tb=short --import-mode=importlib --cov=src --no-cov-on-fail --cov-report=term --cov-report=xml --cov-report=html --cov-fail-under=90"
 
 [tool.pyrefly]
-project-includes = ["src/"]
+project-includes = ["src/", "tests/"]
 min-severity = "warn"
 python-version = "3.12.0"
 preset = "strict"
+python-interpreter-path = ".venv/bin/python"
+# Use inline `# type: ignore` comments, which can be useful.
+permissive-ignores = true
 
 [tool.ruff]
 extend = ".config/ruff.toml"


### PR DESCRIPTION
# Description

Some things needed to be fixed in the settings for Pyrefly to run correctly/effectively. Like pointing to the right Python interpreter and allowing `type: ignore` comments.

Needs no review.

## Checklist

- [x] Ran `just run-all`
