### PR TITLE
fix: 🐛 remove leftover workflow tags from conversion

### DIFF
--- a/template/.github/workflows/build-website.yml.jinja
+++ b/template/.github/workflows/build-website.yml.jinja
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   build-website:
     runs-on: ubuntu-latest
-    {% if hosting_provider == 'gh-pages' -%}
+    {%- if hosting_provider == 'gh-pages' -%}
     with:
       hosting-provider: gh-pages
     permissions:
@@ -61,19 +61,18 @@ jobs:
 
       {% if hosting_provider == 'netlify' -%}
       - name: Publish to Netlify (and render)
-        if: {{ "${{ inputs.hosting-provider == 'netlify' }}" }}
         uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
         with:
           target: netlify
-          NETLIFY_AUTH_TOKEN: {{ '${{ secrets.netlify-token }}' }}
+          # TODO: Make sure to set the Netlify site ID in the repository secrets.
+          NETLIFY_AUTH_TOKEN: {{ '${{ secrets.NETLIFY_AUTH_TOKEN }}' }}
 
       {%- elif hosting_provider == 'gh-pages' -%}
       # NOTE: If Publishing to GitHub Pages, set the permissions correctly (see above).
       - name: Publish to GitHub Pages (and render)
-        if: {{ "${{ inputs.hosting-provider == 'gh-pages' }}" }}
         uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
         with:
           target: gh-pages
         env:
-          GITHUB_TOKEN: {{ '${{ secrets.github-token }}' }}
+          GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
       {%- endif %}


### PR DESCRIPTION
# Description

When I converted from the reusable workflow, I had forgotten to remove some things, like the `if` conditions.

Needs no review.

## Checklist

- [x] Ran `just run-all`
