### PR TITLE
fix: 🐛 bring back Python import organising in VS Code

### DIFF
--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -21,7 +21,10 @@
     "editor.defaultFormatter": "jolars.panache"
   },
   "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff"
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports.ruff": "always",
+    }
   },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.languageServer": "Pylance",


### PR DESCRIPTION
# Description

It was deleted previously because I thought Ruff could do it on it's own, but VS Code needs a specific setting, which I add here.

Needs no review.

## Checklist

- [x] Ran `just run-all`
