### PR TITLE
feat: ✨ allow use of `Optional[]` in Ruff checks

### DIFF
--- a/template/.config/ruff.toml
+++ b/template/.config/ruff.toml
@@ -1,4 +1,4 @@
-# Support Python 3.12+
+# Support Python 3.12+.
 target-version = "py312"
 
 # In addition to the default formatters/linters, add these as well.
@@ -10,19 +10,25 @@ extend-select = [
   "D",
   # Add isort to list.
   "I",
-  # Check for unused arguments
+  # Check for unused arguments.
   "ARG",
 ]
-# Ignore missing docstring at the top of files
-ignore = ["D100"]
+ignore = [
+  # Ignore missing docstring at the top of files.
+  "D100",
+  # Use `Optional[]` typing.
+  "UP045",
+]
 
 [lint.pydocstyle]
 convention = "google"
 
+[lint.per-file-ignores]
+# Ignore "Module imported but unused" error in all init files.
+"__init__.py" = ["F401"]
+# Don't require docstrings and ignore unused arguments in test files.
+# Must move up from the `.config/` directory to the root of the project.
+"../**/tests/*" = ["D", "ARG"]
+
 [format]
 docstring-code-format = true
-
-[lint.per-file-ignores]
-# ignore "Module imported but unused" error in all init files
-"__init__.py" = ["F401"]
-"**/tests/*" = ["D"]


### PR DESCRIPTION
# Description

Ruff recently enabled a lot more lint rules, so this turns that one off.

Needs no review.

## Checklist

- [x] Ran `just run-all`
